### PR TITLE
Add basic static documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ An example script that sends code to the server lives in
 ## Utilities
 
 Reusable math helpers are available in `utils/math.js`.
+
+## Documentation
+
+Static documentation lives in the `docs/` directory. When the server is
+running, visit `http://localhost:3000/` to view the docs, API reference,
+and changelog.

--- a/docs/api.html
+++ b/docs/api.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>SecureRo API</title>
+</head>
+<body>
+  <h1>API Reference</h1>
+  <h2>POST /scan</h2>
+  <p>Request JSON: {"code": "string"}</p>
+  <p>Response JSON: {"issues": [{"line": number, "message": string}]}</p>
+  <p>Returns a list of detected issues with associated line numbers.</p>
+  <p><a href="index.html">Back to documentation home</a></p>
+</body>
+</html>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>SecureRo Changelog</title>
+</head>
+<body>
+  <h1>Changelog</h1>
+  <h2>v1.0.0</h2>
+  <p>Initial prototype release.</p>
+  <p><a href="index.html">Back to documentation home</a></p>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>SecureRo Documentation</title>
+</head>
+<body>
+  <h1>SecureRo Documentation</h1>
+  <p>SecureRo is a prototype Roblox code scanning server and plugin.</p>
+  <ul>
+    <li><a href="api.html">API Reference</a></li>
+    <li><a href="changelog.html">Changelog</a></li>
+  </ul>
+</body>
+</html>

--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,10 @@
 const express = require('express');
+const path = require('path');
 const { scan } = require('./scan');
 
 const app = express();
 app.use(express.json({ limit: '1mb' }));
+app.use(express.static(path.join(__dirname, '..', 'docs')));
 
 app.post('/scan', (req, res) => {
   const { code } = req.body;


### PR DESCRIPTION
## Summary
- Serve a simple documentation site from Express
- Document the `/scan` API and initial release in static HTML pages
- Point README to the new docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6bb658c8883228baaddb5a1fca92c